### PR TITLE
Automate display session approval and gate operator controls

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1,0 +1,810 @@
+// WebAppとしてアクセスされたときに実行されるメイン関数
+function doGet(e) {
+  return ContentService
+    .createTextOutput(JSON.stringify({ success: false, error: 'GET not allowed' }))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+
+// 指定されたシートのデータを読み込んでオブジェクトの配列に変換するヘルパー関数
+function getSheetData(sheetName) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName(sheetName);
+  if (!sheet) {
+    throw new Error(`Sheet "${sheetName}" not found.`);
+  }
+
+  const range = sheet.getDataRange();
+  const values = range.getValues();
+  const headers = values.shift();
+
+  return values.map(row => {
+    const obj = {};
+    headers.forEach((header, index) => {
+      obj[header] = row[index];
+    });
+    return obj;
+  });
+}
+
+const DISPLAY_SESSION_TTL_MS = 60 * 1000;
+
+// WebAppにPOSTリクエストが送られたときに実行される関数
+function doPost(e) {
+  try {
+    const req = parseBody_(e);
+    const { action, idToken } = req;
+    if (!action) throw new Error('Missing action');
+
+    const displayActions = new Set(['beginDisplaySession', 'heartbeatDisplaySession', 'endDisplaySession']);
+    const principal = requireAuth_(idToken, displayActions.has(action) ? { allowAnonymous: true } : {});
+
+    switch (action) {
+      case 'beginDisplaySession':
+        return jsonOk(beginDisplaySession_(principal));
+      case 'heartbeatDisplaySession':
+        return jsonOk(heartbeatDisplaySession_(principal, req.sessionId));
+      case 'endDisplaySession':
+        return jsonOk(endDisplaySession_(principal, req.sessionId, req.reason));
+      case 'ensureAdmin':
+        return jsonOk(ensureAdmin_(principal));
+      case 'mirrorSheet':
+        assertOperator_(principal);
+        return jsonOk(mirrorSheetToRtdb_());
+      case 'fetchSheet':
+        assertOperator_(principal);
+        return jsonOk({ data: getSheetData_(req.sheet) });
+      case 'addTerm':
+        assertOperator_(principal);
+        return jsonOk(addDictionaryTerm(req.term, req.ruby));
+      case 'deleteTerm':
+        assertOperator_(principal);
+        return jsonOk(deleteDictionaryTerm(req.term));
+      case 'toggleTerm':
+        assertOperator_(principal);
+        return jsonOk(toggleDictionaryTerm(req.term, req.enabled));
+      case 'updateStatus':
+        assertOperator_(principal);
+        return jsonOk(updateAnswerStatus(req.uid, req.status));
+      case 'editQuestion':
+        assertOperator_(principal);
+        return jsonOk(editQuestionText(req.uid, req.text));
+      case 'batchUpdateStatus':
+        assertOperator_(principal);
+        return jsonOk(batchUpdateStatus(req.uids, req.status, principal));
+      case 'updateSelectingStatus':
+        assertOperator_(principal);
+        return jsonOk(updateSelectingStatus(req.uid, principal));
+      case 'clearSelectingStatus':
+        assertOperator_(principal);
+        return jsonOk(clearSelectingStatus(principal));
+      case 'logAction':
+        assertOperator_(principal);
+        return jsonOk(logAction_(principal, req.action_type, req.details));
+      case 'whoami':
+        return jsonOk({ principal });
+      default:
+        throw new Error('Unknown action: ' + action);
+    }
+  } catch (err) {
+    return jsonErr_(err);
+  }
+}
+
+function ensureAdmin_(principal){
+  const uid   = principal && principal.uid;
+  const email = String(principal && principal.email || '').trim().toLowerCase();
+  if (!uid || !email) throw new Error('No uid/email');
+
+  const users = getSheetData_('users');
+  const ok = users.some(row => {
+    const m = String(row['メールアドレス'] || row['email'] || '').trim().toLowerCase();
+    return m && m === email;
+  });
+  if (!ok) throw new Error('Not in users sheet');
+
+  const token = getFirebaseAccessToken_();
+  const res = UrlFetchApp.fetch(rtdbUrl_('admins/' + uid), {
+    method: 'put',
+    contentType: 'application/json',
+    payload: 'true',
+    headers: { Authorization: 'Bearer ' + token },
+    muteHttpExceptions: true
+  });
+  return { status: res.getResponseCode() };
+}
+
+function rtdbUrl_(path){
+  const FIREBASE_DB_URL = PropertiesService.getScriptProperties().getProperty('FIREBASE_DB_URL');
+  return FIREBASE_DB_URL.replace(/\/$/, '') + '/' + String(path || '').replace(/^\//,'') + '.json';
+}
+
+function mirrorSheetToRtdb_(){
+  const sh = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('answer');
+  if (!sh) throw new Error('Sheet "answer" not found.');
+  const values = sh.getDataRange().getValues();
+  if (values.length < 2) return {count:0};
+  const headers = values[0].map(h => String(h||'').trim());
+  const norm = s => String(s||'').normalize('NFKC').replace(/\s+/g,'');
+  const idxOf = key => headers.findIndex(h => norm(h) === norm(key));
+  const tsIdx  = idxOf('タイムスタンプ');
+  const nameIdx= idxOf('ラジオネーム');
+  const qIdx   = idxOf('質問・お悩み');
+  const grpIdx = idxOf('班番号');
+  const selIdx = idxOf('選択中');
+  const ansIdx = idxOf('回答済');
+  const uidIdx = idxOf('UID');
+  if (uidIdx<0 || nameIdx<0 || qIdx<0) {
+    throw new Error('必要な列(UID/ラジオネーム/質問・お悩み)が見つかりません');
+  }
+
+  const map = {};
+  for (let r=1; r<values.length; r++){
+    const row = values[r];
+    const uid = String(row[uidIdx]).trim();
+    if (!uid) continue;
+    let tsMs = 0;
+    const v = tsIdx>=0 ? row[tsIdx] : null;
+    if (v instanceof Date) tsMs = v.getTime();
+    else if (typeof v === 'number') {
+      if (v > 20000 && v < 70000) tsMs = Math.round((v - 25569) * 86400 * 1000);
+      else if (v > 1e10) tsMs = v;
+      else if (v > 1e6) tsMs = v * 1000;
+    } else if (typeof v === 'string' && v.trim()) {
+      const s = v.replace(' ', 'T');
+      const d = new Date(s);
+      if (!isNaN(d)) tsMs = d.getTime();
+    }
+    const groupVal = grpIdx>=0 ? row[grpIdx] : '';
+    map[uid] = {
+      uid,
+      name: String(row[nameIdx] ?? ''),
+      question: String(row[qIdx] ?? ''),
+      group: String(groupVal ?? ''),
+      ts: tsMs || 0,
+      answered: Boolean(row[ansIdx] === true),
+      selecting: Boolean(row[selIdx] === true),
+      updatedAt: new Date().getTime()
+    };
+  }
+  const token = getFirebaseAccessToken_();
+  const res = UrlFetchApp.fetch(rtdbUrl_('questions'), {
+    method: 'put',
+    contentType: 'application/json',
+    payload: JSON.stringify(map),
+    headers: { Authorization: 'Bearer ' + token },
+    muteHttpExceptions: true
+  });
+  return { count: Object.keys(map).length, status: res.getResponseCode() };
+}
+
+function logAction_(principal, actionType, details) {
+  const sh = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('logs') 
+            || SpreadsheetApp.getActiveSpreadsheet().insertSheet('logs');
+  if (sh.getLastRow() === 0) {
+    sh.appendRow(['Timestamp','User','Action','Details']);
+  }
+  const userEmail = (principal && principal.email) || 'unknown';
+  const row = [new Date(), userEmail, actionType || '', details || ''];
+  sh.appendRow(row);
+  try { notifyUpdate('logs'); } catch (e) { console.error('notifyUpdate failed', e); }
+  return { ok: true };
+}
+
+function parseBody_(e) {
+  if (!e || !e.postData) throw new Error('No body');
+  const text = e.postData.contents || '';
+  try { return JSON.parse(text); }
+  catch (e2) { throw new Error('Invalid JSON'); }
+}
+
+function requireAuth_(idToken, options){
+  options = options || {};
+  if (!idToken) throw new Error('Missing idToken');
+
+  const KEY = PropertiesService.getScriptProperties().getProperty('FIREBASE_WEB_API_KEY');
+  if (!KEY) throw new Error('Missing FIREBASE_WEB_API_KEY');
+
+  const url = 'https://identitytoolkit.googleapis.com/v1/accounts:lookup?key=' + KEY;
+  const res = UrlFetchApp.fetch(url, {
+    method: 'post',
+    contentType: 'application/json',
+    payload: JSON.stringify({ idToken }),
+    muteHttpExceptions: true,
+  });
+  const code = res.getResponseCode();
+  if (code !== 200) throw new Error('Auth HTTP ' + code);
+
+  const obj = JSON.parse(res.getContentText());
+  const user = obj.users && obj.users[0];
+  if (!user) throw new Error('Auth failed: user not found');
+
+  const providerInfo = Array.isArray(user.providerUserInfo) ? user.providerUserInfo : [];
+  let tokenPayload = null;
+  try {
+    tokenPayload = parseJwt_(idToken);
+  } catch (e) {
+    tokenPayload = null;
+  }
+  const providerIds = providerInfo.map(info => info && info.providerId).filter(Boolean);
+  const signInProvider = tokenPayload && tokenPayload.firebase && tokenPayload.firebase['sign_in_provider'];
+  const isAnonymous = signInProvider === 'anonymous' || ((!user.email || user.email === '') && (providerIds.length === 0 || providerIds.every(id => id === 'anonymous')));
+  const allowAnonymous = options.allowAnonymous === true;
+  if (isAnonymous && !allowAnonymous) throw new Error('Anonymous auth not allowed');
+
+  let email = '';
+  if (!isAnonymous) {
+    email = user.email ||
+      (providerInfo.find(p => p.email) || {}).email ||
+      (tokenPayload && tokenPayload.email ? tokenPayload.email : '') || '';
+
+    const allowed = getAllowedDomains_().map(d => String(d).toLowerCase());
+    if (allowed.length && email) {
+      const domain = String(email).split('@')[1] || '';
+      if (!allowed.includes(domain.toLowerCase())) throw new Error('Unauthorized domain');
+    }
+    if (user.emailVerified !== true) throw new Error('Email not verified');
+  }
+
+  if (user.disabled === true) throw new Error('User disabled');
+
+  return {
+    uid: user.localId,
+    email: String(email || ''),
+    emailVerified: user.emailVerified === true,
+    isAnonymous: isAnonymous
+  };
+}
+
+function parseJwt_(t){
+  const p = t.split('.')[1];
+  return JSON.parse(Utilities.newBlob(Utilities.base64DecodeWebSafe(p)).getDataAsString());
+}
+
+function getAllowedDomains_(){
+  const raw = PropertiesService.getScriptProperties().getProperty('ALLOWED_EMAIL_DOMAINS') || '';
+  return raw.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+function assertOperator_(principal){
+  const email = String(principal && principal.email || '').trim().toLowerCase();
+  if (!email) throw new Error('Forbidden: missing email');
+  const users = getSheetData_('users');
+  const ok = users.some(row =>
+    String(row['メールアドレス'] || row['email'] || '')
+      .trim().toLowerCase() === email
+  );
+  if (!ok) throw new Error('Forbidden: not in users sheet');
+}
+
+function jsonOk(payload){
+  const body = Object.assign({ success: true }, payload || {});
+  return ContentService.createTextOutput(JSON.stringify(body))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+
+function jsonErr_(err){
+  const id = Utilities.getUuid().slice(0, 8);
+  console.error('[' + id + ']', err && err.stack || err);
+  return ContentService.createTextOutput(JSON.stringify({
+    success: false,
+    error: String(err && err.message || err),
+    errorId: id
+  })).setMimeType(ContentService.MimeType.JSON);
+}
+
+function requireSessionId_(raw) {
+  const sessionId = String(raw || '').trim();
+  if (!sessionId) throw new Error('Missing sessionId');
+  return sessionId;
+}
+
+function fetchRtdb_(path, token) {
+  const res = UrlFetchApp.fetch(rtdbUrl_(path), {
+    method: 'get',
+    headers: token ? { Authorization: 'Bearer ' + token } : {},
+    muteHttpExceptions: true
+  });
+  const code = res.getResponseCode();
+  if (code === 200) {
+    const text = res.getContentText();
+    if (!text || text === 'null') return null;
+    return JSON.parse(text);
+  }
+  if (code === 404) return null;
+  throw new Error('RTDB fetch failed: HTTP ' + code);
+}
+
+function patchRtdb_(updates, token) {
+  if (!updates || typeof updates !== 'object') return;
+  const res = UrlFetchApp.fetch(rtdbUrl_(''), {
+    method: 'patch',
+    contentType: 'application/json',
+    payload: JSON.stringify(updates),
+    headers: { Authorization: 'Bearer ' + token },
+    muteHttpExceptions: true
+  });
+  const code = res.getResponseCode();
+  if (code >= 400) {
+    throw new Error('RTDB patch failed: HTTP ' + code + ' ' + res.getContentText());
+  }
+}
+
+function beginDisplaySession_(principal) {
+  if (!principal || principal.isAnonymous !== true) {
+    throw new Error('Only anonymous display accounts can begin sessions');
+  }
+  const token = getFirebaseAccessToken_();
+  const now = Date.now();
+  const current = fetchRtdb_('render_control/session', token);
+  const updates = {};
+
+  if (current && current.sessionId) {
+    const currentExpires = Number(current.expiresAt || 0);
+    if (current.uid && current.uid !== principal.uid) {
+      updates[`screens/approved/${current.uid}`] = null;
+      updates[`screens/sessions/${current.uid}`] = Object.assign({}, current, {
+        status: currentExpires && currentExpires <= now ? 'expired' : 'superseded',
+        endedAt: now,
+        expiresAt: now,
+        lastSeenAt: Number(current.lastSeenAt || now)
+      });
+    } else if (current.uid === principal.uid && currentExpires && currentExpires <= now) {
+      updates[`screens/sessions/${current.uid}`] = Object.assign({}, current, {
+        status: 'expired',
+        endedAt: now,
+        expiresAt: now,
+        lastSeenAt: Number(current.lastSeenAt || now)
+      });
+    }
+  }
+
+  const sessionId = Utilities.getUuid();
+  const expiresAt = now + DISPLAY_SESSION_TTL_MS;
+  const session = {
+    uid: principal.uid,
+    sessionId,
+    status: 'active',
+    startedAt: now,
+    lastSeenAt: now,
+    expiresAt,
+    grantedBy: 'gas'
+  };
+
+  updates[`screens/approved/${principal.uid}`] = true;
+  updates[`screens/sessions/${principal.uid}`] = session;
+  updates['render_control/session'] = session;
+  patchRtdb_(updates, token);
+  return { session };
+}
+
+function heartbeatDisplaySession_(principal, rawSessionId) {
+  if (!principal || principal.isAnonymous !== true) {
+    throw new Error('Only anonymous display accounts can send heartbeats');
+  }
+  const sessionId = requireSessionId_(rawSessionId);
+  const token = getFirebaseAccessToken_();
+  const now = Date.now();
+  const current = fetchRtdb_('render_control/session', token);
+  if (!current || current.uid !== principal.uid || current.sessionId !== sessionId) {
+    if (current && Number(current.expiresAt || 0) <= now) {
+      const updates = {};
+      updates['render_control/session'] = null;
+      if (current.uid) {
+        updates[`screens/approved/${current.uid}`] = null;
+        updates[`screens/sessions/${current.uid}`] = Object.assign({}, current, {
+          status: 'expired',
+          endedAt: now,
+          expiresAt: now,
+          lastSeenAt: Number(current.lastSeenAt || now)
+        });
+      }
+      patchRtdb_(updates, token);
+    }
+    return { active: false };
+  }
+
+  if (Number(current.expiresAt || 0) <= now) {
+    const updates = {};
+    updates['render_control/session'] = null;
+    updates[`screens/approved/${current.uid}`] = null;
+    updates[`screens/sessions/${current.uid}`] = Object.assign({}, current, {
+      status: 'expired',
+      endedAt: now,
+      expiresAt: now,
+      lastSeenAt: Number(current.lastSeenAt || now)
+    });
+    patchRtdb_(updates, token);
+    return { active: false };
+  }
+
+  const session = Object.assign({}, current, {
+    status: 'active',
+    lastSeenAt: now,
+    expiresAt: now + DISPLAY_SESSION_TTL_MS
+  });
+  const updates = {};
+  updates[`screens/approved/${principal.uid}`] = true;
+  updates[`screens/sessions/${principal.uid}`] = session;
+  updates['render_control/session'] = session;
+  patchRtdb_(updates, token);
+  return { active: true, session };
+}
+
+function endDisplaySession_(principal, rawSessionId, reason) {
+  if (!principal || principal.isAnonymous !== true) {
+    throw new Error('Only anonymous display accounts can end sessions');
+  }
+  const sessionId = requireSessionId_(rawSessionId);
+  const token = getFirebaseAccessToken_();
+  const now = Date.now();
+  const current = fetchRtdb_('render_control/session', token);
+  if (!current || current.uid !== principal.uid || current.sessionId !== sessionId) {
+    return { ended: false };
+  }
+
+  const session = Object.assign({}, current, {
+    status: 'ended',
+    endedAt: now,
+    expiresAt: now,
+    lastSeenAt: now,
+    endedReason: reason || null
+  });
+  const updates = {};
+  updates[`screens/approved/${principal.uid}`] = null;
+  updates[`screens/sessions/${principal.uid}`] = session;
+  updates['render_control/session'] = null;
+  patchRtdb_(updates, token);
+  return { ended: true };
+}
+
+function updateSelectingStatus(uid) {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('answer');
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0];
+  const uidColIndex = headers.indexOf('UID');
+  const selectingColIndex = headers.indexOf('選択中');
+
+  if (uidColIndex === -1 || selectingColIndex === -1) {
+    throw new Error('Column "UID" or "選択中" not found.');
+  }
+
+  const numRows = data.length - 1;
+  if (numRows > 0) {
+    const selectingRange = sheet.getRange(2, selectingColIndex + 1, numRows, 1);
+    const cleared = Array.from({ length: numRows }, () => [false]);
+    selectingRange.setValues(cleared);
+  }
+
+  for (let i = 1; i < data.length; i++) {
+    if (data[i][uidColIndex] == uid) {
+      sheet.getRange(i + 1, selectingColIndex + 1).setValue(true);
+      return { success: true, message: `UID: ${uid} is now selecting.` };
+    }
+  }
+
+  throw new Error(`UID: ${uid} not found.`);
+}
+
+function editQuestionText(uid, newText) {
+  if (!uid || typeof newText === 'undefined') {
+    throw new Error('UID and new text are required.');
+  }
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('answer');
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0];
+  const uidColIndex = headers.indexOf('UID');
+  const questionColIndex = headers.indexOf('質問・お悩み');
+
+  if (uidColIndex === -1 || questionColIndex === -1) {
+    throw new Error('Column "UID" or "質問・お悩み" not found.');
+  }
+
+  for (let i = 1; i < data.length; i++) {
+    if (data[i][uidColIndex] == uid) {
+      sheet.getRange(i + 1, questionColIndex + 1).setValue(newText);
+      return { success: true, message: `UID: ${uid} question updated.` };
+    }
+  }
+
+  throw new Error(`UID: ${uid} not found.`);
+}
+
+function updateAnswerStatus(uid, status) {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('answer');
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0];
+  const uidColIndex = headers.indexOf('UID');
+  const answeredColIndex = headers.indexOf('回答済');
+
+  if (uidColIndex === -1 || answeredColIndex === -1) {
+    throw new Error('Column "UID" or "回答済" not found.');
+  }
+
+  for (let i = 1; i < data.length; i++) {
+    if (data[i][uidColIndex] == uid) {
+      const isAnswered = status === true || status === 'true' || status === 1;
+      sheet.getRange(i + 1, answeredColIndex + 1).setValue(isAnswered);
+      return { success: true, message: `UID: ${uid} updated.` };
+    }
+  }
+
+  throw new Error(`UID: ${uid} not found.`);
+}
+
+function addDictionaryTerm(term, ruby) {
+  if (!term || !ruby) {
+    throw new Error('Term and ruby are required.');
+  }
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('dictionary');
+  sheet.appendRow([term, ruby, 'default', true]);
+  return { success: true, message: `Term "${term}" added.` };
+}
+
+function deleteDictionaryTerm(term) {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('dictionary');
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0];
+  const lower = headers.map(h => String(h||'').toLowerCase());
+  const termColIndex = lower.indexOf('term');
+
+  for (let i = data.length - 1; i > 0; i--) {
+    if (data[i][termColIndex] === term) {
+      sheet.deleteRow(i + 1);
+      return { success: true, message: `Term "${term}" deleted.` };
+    }
+  }
+  throw new Error(`Term "${term}" not found.`);
+}
+
+function toggleDictionaryTerm(term, enabled) {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('dictionary');
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0];
+  const lower = headers.map(h => String(h||'').toLowerCase());
+  const termColIndex = lower.indexOf('term');
+  const enabledColIndex = lower.indexOf('enabled');
+
+  for (let i = 1; i < data.length; i++) {
+    if (data[i][termColIndex] === term) {
+      sheet.getRange(i + 1, enabledColIndex + 1).setValue(enabled);
+      return { success: true, message: `Term "${term}" status updated.` };
+    }
+  }
+  throw new Error(`Term "${term}" not found.`);
+}
+
+function dailyCheckAndResetUserForm() {
+    const today = new Date();
+    const month = today.getMonth() + 1;
+    const day = today.getDate();
+
+    if (month === 5 && day === 1) {
+        const ss = SpreadsheetApp.getActiveSpreadsheet();
+        const formUrl = ss.getFormUrl(); 
+        
+        if (formUrl) {
+            const form = FormApp.openByUrl(formUrl);
+            form.deleteAllResponses();
+            Logger.log("User registration form has been reset.");
+        } else {
+            const userSheet = ss.getSheetByName('users');
+            if(userSheet && userSheet.getLastRow() > 1) {
+               userSheet.getRange(2, 1, userSheet.getLastRow() - 1, userSheet.getLastColumn()).clearContent();
+               Logger.log("User sheet has been cleared.");
+            }
+        }
+    }
+}
+
+function getFirebaseAccessToken_() {
+  const properties = PropertiesService.getScriptProperties();
+  const CLIENT_EMAIL = properties.getProperty('CLIENT_EMAIL');
+  const privateKeyFromProperties = properties.getProperty('PRIVATE_KEY');
+  const PRIVATE_KEY = privateKeyFromProperties.replace(/\\n/g, '\n');
+
+  const header = {
+    alg: "RS256",
+    typ: "JWT"
+  };
+
+  const now = Math.floor(Date.now() / 1000);
+  const claimSet = {
+    iss: CLIENT_EMAIL,
+    sub: CLIENT_EMAIL,
+    aud: "https://oauth2.googleapis.com/token",
+    iat: now,
+    exp: now + 3600,
+    scope: "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/firebase.database"
+  };
+
+  const jwtHeader = Utilities.base64EncodeWebSafe(JSON.stringify(header));
+  const jwtClaimSet = Utilities.base64EncodeWebSafe(JSON.stringify(claimSet));
+  const signatureInput = `${jwtHeader}.${jwtClaimSet}`;
+
+  const signature = Utilities.computeRsaSha256Signature(signatureInput, PRIVATE_KEY);
+  const encodedSignature = Utilities.base64EncodeWebSafe(signature);
+
+  const signedJwt = `${signatureInput}.${encodedSignature}`;
+
+  const response = UrlFetchApp.fetch("https://oauth2.googleapis.com/token", {
+    method: "post",
+    contentType: "application/x-www-form-urlencoded",
+    payload: {
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: signedJwt
+    }
+  });
+
+  const responseData = JSON.parse(response.getContentText());
+  return responseData.access_token;
+}
+
+function notifyUpdate(kind) {
+  const lock = LockService.getScriptLock();
+  if (lock.tryLock(10000)) {
+    try {
+      const properties = PropertiesService.getScriptProperties();
+      const FIREBASE_DB_URL = properties.getProperty('FIREBASE_DB_URL');
+      const accessToken = getFirebaseAccessToken_();
+
+      if (kind !== 'logs') {
+        mirrorSheetToRtdb_();
+      }
+      const url = `${FIREBASE_DB_URL}/update_trigger.json`;
+      const payload = new Date().getTime();
+
+      const options = {
+        method: 'put',
+        contentType: 'application/json',
+        payload: JSON.stringify(payload),
+        headers: {
+          Authorization: 'Bearer ' + accessToken
+        },
+        muteHttpExceptions: true
+      };
+
+      const response = UrlFetchApp.fetch(url, options);
+      Logger.log('Firebase notified via OAuth2. Response: ' + response.getContentText());
+
+    } finally {
+      lock.releaseLock();
+    }
+  }
+}
+
+function diagnoseSheetConnection() {
+  try {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    Logger.log(`診断開始：スクリプトは "${ss.getName()}" という名前のスプレッドシートに接続されています。`);
+    
+    const sheet = ss.getSheetByName('logs');
+    if (sheet) {
+      Logger.log('成功： "logs" という名前のシートが見つかりました。');
+      sheet.getRange("E1").setValue("テスト書き込み成功：" + new Date());
+      Browser.msgBox('成功！', '"logs" という名前のシートが見つかり、テスト書き込みを行いました。E1セルを確認してください。', Browser.Buttons.OK);
+    } else {
+      Logger.log('失敗： "logs" という名前のシートがこのスプレッドシートには見つかりません。');
+      const allSheetNames = ss.getSheets().map(s => s.getName());
+      Logger.log(`現在認識されているシート名の一覧: [${allSheetNames.join(", ")}]`);
+      Browser.msgBox('失敗！', '"logs" という名前のシートが見つかりませんでした。詳細は実行ログを確認してください。', Browser.Buttons.OK);
+    }
+  } catch (e) {
+    Logger.log('致命的なエラーが発生しました: ' + e.toString());
+    Browser.msgBox('エラー', '診断中に致命的なエラーが発生しました。実行ログを確認してください。', Browser.Buttons.OK);
+  }
+}
+
+function batchUpdateStatus(uids, status) {
+  if (!uids || !Array.isArray(uids)) {
+    throw new Error('UIDs array is required.');
+  }
+  try {
+    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('answer');
+    const data = sheet.getDataRange().getValues();
+    const headers = data[0];
+    const uidColIndex = headers.indexOf('UID');
+    const answeredColIndex = headers.indexOf('回答済');
+
+    if (uidColIndex === -1 || answeredColIndex === -1) {
+      throw new Error('Column "UID" or "回答済" not found.');
+    }
+
+    const uidSet = new Set((uids || []).map(String));
+    const isAnswered = status === true || status === 'true' || status === 1;
+    for (let i = 1; i < data.length; i++) {
+      if (uidSet.has(String(data[i][uidColIndex]))) {
+        sheet.getRange(i + 1, answeredColIndex + 1).setValue(isAnswered);
+      }
+    }
+
+    return { success: true, message: `${uids.length} items updated.` };
+
+  } catch (error) {
+    return { success: false, error: error.message };
+
+  }
+}
+
+function clearSelectingStatus() {
+  try {
+    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('answer');
+    const data = sheet.getDataRange().getValues();
+    const headers = data[0];
+    const selectingColIndex = headers.indexOf('選択中');
+    if (selectingColIndex === -1) throw new Error('Column "選択中" not found.');
+
+    const numRows = data.length - 1;
+    if (numRows <= 0) {
+      return { success: true };
+    }
+    const range = sheet.getRange(2, selectingColIndex + 1, numRows, 1);
+    const values = range.getValues();
+    let changed = false;
+    for (let i = 0; i < values.length; i++) {
+      if (values[i][0] === true) { values[i][0] = false; changed = true; }
+    }
+    if (changed) range.setValues(values);
+
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+}
+
+function toIsoJst_(d){ return Utilities.formatDate(d,'Asia/Tokyo',"yyyy-MM-dd'T'HH:mm:ssXXX"); }
+
+function getSheetData_(sheetKey) {
+  if (!sheetKey) throw new Error('Missing sheet');
+
+  const ALLOW = {
+    answer:     'answer',
+    dictionary: 'dictionary',
+    users:      'users',
+    logs:       'logs',
+  };
+  const sheetName = ALLOW[String(sheetKey)];
+  if (!sheetName) throw new Error('Invalid sheet: ' + sheetKey);
+
+  const sh = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
+  if (!sh) throw new Error('Sheet not found: ' + sheetName);
+
+  const range = sh.getDataRange();
+  const values = range.getValues();
+  if (values.length < 2) return [];
+
+  if (sheetKey === 'logs') {
+    const out = [];
+    for (let r = 1; r < values.length; r++) {
+      const row = values[r];
+      if (!row || row.length === 0 || row.every(v => v === '' || v == null)) continue;
+      let ts = row[0];
+      if (ts instanceof Date) ts = toIsoJst_(ts);
+      out.push({
+        Timestamp: ts || '',
+        User:      String(row[1] ?? ''),
+        Action:    String(row[2] ?? ''),
+        Details:   String(row[3] ?? '')
+      });
+    }
+    return out;
+  }
+
+  const headers = values[0].map(h =>
+    String(h || '')
+      .normalize('NFKC')
+      .replace(/[\u200B-\u200D\uFEFF]/g, '')
+      .trim()
+  );
+  const out = [];
+  for (let r=1; r<values.length; r++){
+    const obj = {};
+    for (let c=0; c<headers.length; c++){
+      const key = headers[c] || ('COL'+(c+1));
+      let v = values[r][c];
+      if (key.toLowerCase()==='timestamp' && v instanceof Date) v = toIsoJst_(v);
+      obj[key] = v;
+    }
+    out.push(obj);
+  }
+  return out;
+}

--- a/display.html
+++ b/display.html
@@ -320,6 +320,7 @@
     [data-probe],
     [data-probe] * { animation: none !important; transition: none !important; }
     [data-probe] .telop-box::after { content: none !important; }
+
   </style>
 </head>
 <body>
@@ -363,101 +364,290 @@
         const database = getDatabase(app);
         const auth = getAuth(app);
 
-        let canReportRender = false;
-        let approvalChecked = false;
-        let unsubscribeApproval = null;
-        let approvalWaitingLogged = false;
-        let approvalEnabledLogged = false;
-        let approvalUnreadableLogged = false;
+        const GAS_API_URL = 'https://script.google.com/macros/s/AKfycbxYtklsVbr2OmtaMISPMw0x2u0shjiUdwkym2oTZW7Xk14pcWxXG1lTcVC2GZAzjobapQ/exec';
+
+        const HEARTBEAT_INTERVAL_MS = 20000;
+        const SESSION_RETRY_DELAY_MS = 8000;
+
+        let sessionInfo = null;
+        let sessionActive = false;
         let reportSuppressedLogged = false;
+        let pendingRenderUpdate = null;
+        let pendingFlushTimer = null;
+        let sessionRetryTimer = null;
+        let heartbeatTimer = null;
+        let latestIdToken = null;
+        let beginInFlight = null;
+
+        function clearPendingFlushTimer() {
+          if (pendingFlushTimer) {
+            clearTimeout(pendingFlushTimer);
+            pendingFlushTimer = null;
+          }
+        }
+
+        function clearSessionRetryTimer() {
+          if (sessionRetryTimer) {
+            clearTimeout(sessionRetryTimer);
+            sessionRetryTimer = null;
+          }
+        }
+
+        function stopHeartbeat() {
+          if (heartbeatTimer) {
+            clearInterval(heartbeatTimer);
+            heartbeatTimer = null;
+          }
+        }
+
+        function startHeartbeat() {
+          stopHeartbeat();
+          heartbeatTimer = setInterval(() => {
+            heartbeatDisplaySession().catch(err => {
+              console.warn('Display heartbeat failed:', err);
+            });
+          }, HEARTBEAT_INTERVAL_MS);
+        }
+
+        function scheduleSessionRetry(delayMs = SESSION_RETRY_DELAY_MS) {
+          if (sessionRetryTimer) return;
+          sessionRetryTimer = setTimeout(() => {
+            sessionRetryTimer = null;
+            if (!auth.currentUser) return;
+            beginDisplaySession().catch(err => {
+              console.error('Display session restart failed:', err);
+              scheduleSessionRetry(Math.min(delayMs * 1.5, 30000));
+            });
+          }, delayMs);
+        }
+
+        // render_state を更新できるよう、セッション待ちの間は一定間隔で再送をリトライ
+        function schedulePendingFlush(delayMs = 5000) {
+          if (pendingFlushTimer) return;
+          pendingFlushTimer = setTimeout(() => {
+            pendingFlushTimer = null;
+            if (!pendingRenderUpdate) return;
+            if (!sessionActive) {
+              scheduleSessionRetry();
+              return;
+            }
+            console.debug('Retrying deferred render_state update after session resume.');
+            flushPendingRender('retry');
+          }, delayMs);
+        }
+
+        function cloneInfo(info) {
+          if (!info) return {};
+          try {
+            return JSON.parse(JSON.stringify(info));
+          } catch (_) {
+            return { ...info };
+          }
+        }
+
+        function resetSessionState() {
+          sessionInfo = null;
+          sessionActive = false;
+          reportSuppressedLogged = false;
+          pendingRenderUpdate = null;
+          clearPendingFlushTimer();
+          clearSessionRetryTimer();
+          stopHeartbeat();
+          beginInFlight = null;
+        }
+
+        async function callGas(action, extra = {}) {
+          const user = auth.currentUser;
+          if (!user) throw new Error('Not signed in');
+          const idToken = await user.getIdToken();
+          latestIdToken = idToken;
+          const res = await fetch(GAS_API_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'text/plain' },
+            body: JSON.stringify({ action, idToken, ...extra })
+          });
+          let json;
+          try {
+            json = await res.json();
+          } catch (err) {
+            throw new Error('Invalid JSON response from GAS');
+          }
+          if (!json.success) {
+            throw new Error(String(json.error || 'GAS request failed'));
+          }
+          return json;
+        }
+
+        function setSessionActive(active) {
+          sessionActive = active === true;
+          if (sessionActive) {
+            reportSuppressedLogged = false;
+            flushPendingRender('session ready');
+          }
+        }
+
+        async function beginDisplaySession() {
+          if (beginInFlight) return beginInFlight;
+          const user = auth.currentUser;
+          if (!user) return;
+          beginInFlight = (async () => {
+            clearSessionRetryTimer();
+            try {
+              const result = await callGas('beginDisplaySession');
+              if (!result.session || !result.session.sessionId) {
+                throw new Error('Invalid session payload');
+              }
+              sessionInfo = result.session;
+              console.info('Display anonymous UID:', user.uid, 'sessionId:', sessionInfo.sessionId);
+              setSessionActive(true);
+              startHeartbeat();
+              return sessionInfo;
+            } catch (err) {
+              setSessionActive(false);
+              scheduleSessionRetry();
+              throw err;
+            } finally {
+              beginInFlight = null;
+            }
+          })();
+          return beginInFlight;
+        }
+
+        async function heartbeatDisplaySession() {
+          if (!sessionInfo || !sessionInfo.sessionId) {
+            await beginDisplaySession();
+            return;
+          }
+          try {
+            const result = await callGas('heartbeatDisplaySession', { sessionId: sessionInfo.sessionId });
+            if (result.active === false) {
+              console.warn('Display session heartbeat rejected; restarting session.');
+              setSessionActive(false);
+              scheduleSessionRetry(2000);
+              return;
+            }
+            if (result.session && result.session.sessionId === sessionInfo.sessionId) {
+              sessionInfo = result.session;
+            }
+            setSessionActive(true);
+          } catch (err) {
+            console.warn('Display heartbeat error:', err);
+          }
+        }
+
+        async function endDisplaySession(reason) {
+          if (!sessionInfo || !sessionInfo.sessionId) return;
+          try {
+            await callGas('endDisplaySession', { sessionId: sessionInfo.sessionId, reason });
+          } catch (err) {
+            console.warn('Failed to end display session:', err);
+          }
+        }
+
+        function sendSessionEndBeacon(reason) {
+          if (!sessionInfo || !sessionInfo.sessionId || !latestIdToken) return false;
+          try {
+            const payload = JSON.stringify({
+              action: 'endDisplaySession',
+              idToken: latestIdToken,
+              sessionId: sessionInfo.sessionId,
+              reason: reason || 'beacon'
+            });
+            const blob = new Blob([payload], { type: 'application/json' });
+            return navigator.sendBeacon(GAS_API_URL, blob);
+          } catch (err) {
+            console.warn('sendBeacon failed:', err);
+            return false;
+          }
+        }
 
         onAuthStateChanged(auth, (user) => {
-          if (typeof unsubscribeApproval === 'function') {
-            unsubscribeApproval();
-            unsubscribeApproval = null;
-          }
-
           if (!user) {
-            canReportRender = false;
-            approvalChecked = false;
-            approvalWaitingLogged = false;
-            approvalEnabledLogged = false;
-            approvalUnreadableLogged = false;
-            reportSuppressedLogged = false;
+            resetSessionState();
             signInAnonymously(auth).catch(err => {
               console.error('Anonymous sign-in failed:', err);
             });
             return;
           }
-
-          const approvalRef = ref(database, `screens/approved/${user.uid}`);
-          unsubscribeApproval = onValue(approvalRef, (snapshot) => {
-            approvalChecked = true;
-            const approved = snapshot.exists() && snapshot.val() === true;
-
-            if (approved) {
-              canReportRender = true;
-              reportSuppressedLogged = false;
-              approvalWaitingLogged = false;
-              approvalUnreadableLogged = false;
-              if (!approvalEnabledLogged) {
-                console.info('Display UID approved; render_state updates enabled.');
-                approvalEnabledLogged = true;
-              }
-              return;
-            }
-
-            canReportRender = false;
-            approvalEnabledLogged = false;
-            if (!approvalWaitingLogged) {
-              console.warn('Display UID is not yet approved. Waiting for operator approval before writing render_state.');
-              approvalWaitingLogged = true;
-            }
-          }, (error) => {
-            approvalChecked = true;
-            canReportRender = false;
-            approvalEnabledLogged = false;
-            if (error && error.code === 'PERMISSION_DENIED') {
-              if (!approvalUnreadableLogged) {
-                console.warn('Display approval status is not readable under current Firebase rules; render_state writes suppressed until approval is granted.');
-                approvalUnreadableLogged = true;
-              }
-              return;
-            }
-            console.error('Failed to confirm display approval status:', error);
+          beginDisplaySession().catch(err => {
+            console.error('Failed to establish display session:', err);
           });
         });
-    
+
+        window.addEventListener('pagehide', () => {
+          sendSessionEndBeacon('pagehide');
+        });
+
+        window.addEventListener('beforeunload', () => {
+          sendSessionEndBeacon('beforeunload');
+        });
+
+        window.addEventListener('visibilitychange', () => {
+          if (document.visibilityState === 'hidden') {
+            sendSessionEndBeacon('hidden');
+          }
+        });
+
         const currentTelopRef = ref(database, 'currentTelop');
         const renderRef = ref(database, 'render_state');
-      
-        // ★ 状態レポート（display → Firebase）
-        function reportRender(phase, info = {}) {
-          if (!canReportRender) {
-            if (approvalChecked && !reportSuppressedLogged) {
-              console.debug('render_state update skipped because this display is not approved yet.');
+
+        function flushPendingRender(reason) {
+          if (!pendingRenderUpdate) return;
+          if (!sessionActive) {
+            scheduleSessionRetry();
+            return;
+          }
+          const pending = pendingRenderUpdate;
+          if (reason === 'retry') {
+            console.debug('Flushing deferred render_state update (scheduled retry).');
+          } else if (reason) {
+            console.info(`Flushing deferred render_state update (${reason}).`);
+          } else {
+            console.info('Flushing deferred render_state update.');
+          }
+          pendingRenderUpdate = null;
+          writeRenderState(pending.phase, pending.info, { force: true });
+        }
+
+        function writeRenderState(phase, info = {}, { force = false } = {}) {
+          if (!force && !sessionActive) {
+            pendingRenderUpdate = { phase, info: cloneInfo(info) };
+            if (!reportSuppressedLogged) {
+              console.debug('render_state update deferred until display session is active.');
               reportSuppressedLogged = true;
             }
+            schedulePendingFlush(2000);
+            beginDisplaySession().catch(() => {});
             return Promise.resolve();
           }
 
           const payload = {
-            phase,                                        // 'showing' | 'visible' | 'hiding' | 'hidden' | 'error'
+            phase,
             updatedAt: serverTimestamp(),
-            ...info                                       // { name, uid, seq など任意}
+            ...info
           };
-          return update(renderRef, payload).catch(err => {
+
+          return update(renderRef, payload).then(() => {
+            pendingRenderUpdate = null;
+            clearPendingFlushTimer();
+            reportSuppressedLogged = false;
+            setSessionActive(true);
+          }).catch(err => {
             if (err && err.code === 'PERMISSION_DENIED') {
-              canReportRender = false;
-              approvalEnabledLogged = false;
-              if (!approvalWaitingLogged) {
-                console.warn('render_state update was denied. Waiting for operator approval before retrying.');
-                approvalWaitingLogged = true;
-              }
+              pendingRenderUpdate = { phase, info: cloneInfo(info) };
+              setSessionActive(false);
+              console.warn('render_state update denied; retrying after session renewal.');
+              schedulePendingFlush();
+              scheduleSessionRetry();
               return;
             }
             console.error(err);
           });
+        }
+
+        // ★ 状態レポート（display → Firebase）
+        function reportRender(phase, info = {}) {
+          return writeRenderState(phase, info);
         }
     
         const radioNameEl = document.getElementById('radio-name');

--- a/firebase.rules.json
+++ b/firebase.rules.json
@@ -1,0 +1,74 @@
+{
+  "rules": {
+    ".read": false,
+    ".write": false,
+
+    "render_state": {
+      ".read": true,
+      ".write": "auth != null && auth.token.firebase.sign_in_provider === 'anonymous' && root.child('screens/approved').child(auth.uid).val() == true",
+      ".validate": "newData.hasChildren(['phase'])",
+      "phase": {
+        ".validate": "newData.isString() && newData.val().matches(/^(visible|hidden|showing|hiding|error)$/)"
+      },
+      "updatedAt": { ".validate": "newData.isNumber() || !newData.exists()" },
+      "nowShowing": {
+        ".validate": "!newData.exists() || (newData.hasChildren(['name','question']) && newData.child('name').isString() && newData.child('question').isString())"
+      }
+    },
+
+    "currentTelop": {
+      ".read": true,
+      ".write": "auth != null && root.child('admins').child(auth.uid).val() == true"
+    },
+
+    "questions": {
+      ".read": "auth != null",
+      "$uid": {
+        ".write": "auth != null && root.child('admins').child(auth.uid).val() == true",
+        ".validate": "newData.hasChildren(['uid','name','question'])",
+        "uid":       { ".validate": "newData.isString()" },
+        "name":      { ".validate": "newData.isString()" },
+        "question":  { ".validate": "newData.isString()" },
+        "answered":  { ".validate": "newData.isBoolean() || !newData.exists()" },
+        "selecting": { ".validate": "newData.isBoolean() || !newData.exists()" },
+        "updatedAt": { ".validate": "newData.isNumber()  || !newData.exists()" },
+        "$other":    { ".validate": false }
+      }
+    },
+
+    "dictionary": {
+      ".read": true,
+      ".write": "auth != null && root.child('admins').child(auth.uid).val() == true"
+    },
+
+    "update_trigger": {
+      ".read": true,
+      ".write": "auth != null"
+    },
+
+    "admins": {
+      ".read": false,
+      ".write": "auth != null && root.child('admins').child(auth.uid).val() == true"
+    },
+
+    "render_control": {
+      ".read": "auth != null && root.child('admins').child(auth.uid).val() == true",
+      ".write": false
+    },
+
+    "screens": {
+      "approved": {
+        "$uid": {
+          ".read": "auth != null && auth.token.firebase.sign_in_provider === 'anonymous' && auth.uid === $uid",
+          ".write": false
+        }
+      },
+      "sessions": {
+        "$uid": {
+          ".read": "auth != null && root.child('admins').child(auth.uid).val() == true",
+          ".write": false
+        }
+      }
+    }
+  }
+}

--- a/style.css
+++ b/style.css
@@ -24,6 +24,8 @@ body {
 .op-theme{ background:var(--bg); color:var(--text); }
 body.op-theme{ padding:20px; margin-bottom:100px; }
 
+.visually-hidden{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); border:0; }
+
 /* グリッド背景（オペ室っぽく） */
 #questions-content{
   background:
@@ -219,6 +221,8 @@ body.op-theme{ padding:20px; margin-bottom:100px; }
 #user-info { position: fixed; top: 10px; right: 20px; font-size: 14px; z-index: 100; }
 
 .panel { flex: 1; }
+
+
 /* ===== Questions Table ===== */
 table{ border-collapse:separate; border-spacing:0; width:100%; margin-top:12px; }
 #questions-table{ background:var(--panel); border:1px solid var(--line); border-radius:12px; overflow:hidden; }


### PR DESCRIPTION
## Summary
- let the display client establish sessions through GAS, retry heartbeats, and defer render_state writes until the session is active
- remove the manual display approval form from the operator UI and disable telop actions whenever no active display session is present
- add GAS endpoints and helpers that accept anonymous display tokens, manage session lifecycle data in Firebase, and introduced matching security rules exposing read-only session state to operators
- fix anonymous display detection in GAS so sessions accept signed-in display clients and ensure operator action gating initializes after state setup

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e65172abfc83258c9dd80178014ab6