### PR TITLE
Fix selection sync and ruby rendering

### DIFF
--- a/display.html
+++ b/display.html
@@ -869,17 +869,70 @@
         // テキストにルビを適用する関数
         function applyRuby(text) {
             if (!text) return '';
-            let processedText = escapeHtml(text); // ベースをサニタイズ
-            dictionary.forEach(item => {
-                // 正規表現で単語を検索し、<ruby>タグに置換する
-                // 'g'フラグですべてのマッチを置換
-                const regex = new RegExp(escapeRegExp(item.term), 'g');
-                processedText = processedText.replace(
-                  regex,
-                  `<ruby>${escapeHtml(item.term)}<rt>${escapeHtml(item.ruby)}</rt></ruby>`
-                );
+            const base = document.createElement('div');
+            base.textContent = String(text);
+            const entries = Array.isArray(dictionary)
+              ? dictionary
+                  .map(item => ({
+                    term: String(item?.term ?? ''),
+                    ruby: String(item?.ruby ?? '')
+                  }))
+                  .filter(entry => entry.term && entry.ruby)
+              : [];
+            if (!entries.length) {
+              return base.innerHTML;
+            }
+
+            entries.sort((a, b) => b.term.length - a.term.length);
+            const patternSource = entries.map(entry => escapeRegExp(entry.term)).join('|');
+            if (!patternSource) {
+              return base.innerHTML;
+            }
+            const entryMap = new Map();
+            entries.forEach(entry => {
+              if (!entryMap.has(entry.term)) entryMap.set(entry.term, entry);
             });
-            return processedText;
+
+            const walker = document.createTreeWalker(base, NodeFilter.SHOW_TEXT);
+            const textNodes = [];
+            while (walker.nextNode()) {
+              textNodes.push(walker.currentNode);
+            }
+
+            for (const node of textNodes) {
+              const value = node.nodeValue;
+              if (!value) continue;
+              const regex = new RegExp(patternSource, 'g');
+              let match;
+              let lastIndex = 0;
+              const frag = document.createDocumentFragment();
+              while ((match = regex.exec(value)) !== null) {
+                const { index } = match;
+                if (index > lastIndex) {
+                  frag.appendChild(document.createTextNode(value.slice(lastIndex, index)));
+                }
+                const matchedText = match[0];
+                const entry = entryMap.get(matchedText);
+                if (entry) {
+                  const rubyEl = document.createElement('ruby');
+                  rubyEl.appendChild(document.createTextNode(matchedText));
+                  const rtEl = document.createElement('rt');
+                  rtEl.textContent = entry.ruby;
+                  rubyEl.appendChild(rtEl);
+                  frag.appendChild(rubyEl);
+                } else {
+                  frag.appendChild(document.createTextNode(matchedText));
+                }
+                lastIndex = index + matchedText.length;
+              }
+              if (lastIndex === 0) continue; // 置換なし
+              if (lastIndex < value.length) {
+                frag.appendChild(document.createTextNode(value.slice(lastIndex)));
+              }
+              node.replaceWith(frag);
+            }
+
+            return base.innerHTML;
         }
         
         function escapeHtml(s){

--- a/operator.js
+++ b/operator.js
@@ -500,7 +500,8 @@ async function renderQuestions() {
 
   const snap = await get(telopRef);
   const live = snap.val();
-  const selectedUid = state.selectedRowData ? state.selectedRowData.uid : null;
+  const selectedUid = state.selectedRowData ? String(state.selectedRowData.uid) : null;
+  let nextSelection = null;
 
   // --- カード描画 ---
   const host = dom.cardsContainer;
@@ -523,7 +524,16 @@ async function renderQuestions() {
         state.lastDisplayedUid = null;
       }
     }
-    if (item['UID'] === selectedUid) card.classList.add('is-selected');
+    const uid = String(item['UID']);
+    if (uid === selectedUid) {
+      card.classList.add('is-selected');
+      nextSelection = {
+        uid,
+        name: item['ラジオネーム'],
+        question: item['質問・お悩み'],
+        isAnswered
+      };
+    }
 
     card.innerHTML = `
       <header class="q-head">
@@ -554,7 +564,7 @@ async function renderQuestions() {
       host.querySelectorAll('.q-card').forEach(el => el.classList.remove('is-selected'));
       card.classList.add('is-selected');
       state.selectedRowData = {
-        uid: item['UID'],
+        uid,
         name: item['ラジオネーム'],
         question: item['質問・お悩み'],
         isAnswered
@@ -565,7 +575,10 @@ async function renderQuestions() {
     host.appendChild(card);
   });
 
-  if (!list.some(x => x['UID'] === selectedUid)) {
+  if (selectedUid && nextSelection) {
+    state.selectedRowData = nextSelection;
+    updateActionAvailability();
+  } else if (!list.some(x => String(x['UID']) === selectedUid)) {
     state.selectedRowData = null;
     updateActionAvailability();
   }


### PR DESCRIPTION
## Summary
- keep the cached selected question in sync with realtime updates so action buttons reflect the latest status
- rework the ruby application on the display to replace text nodes safely and avoid nested markup when terms overlap

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e6807731988325b98c9c7382ac9b30