### PR TITLE
Ensure display uses anonymous auth and add inline favicon

### DIFF
--- a/display.html
+++ b/display.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Telop Display</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2064%2064%27%3E%0A%20%20%3Crect%20width%3D%2764%27%20height%3D%2764%27%20rx%3D%2712%27%20fill%3D%27%2305111f%27%2F%3E%0A%20%20%3Ctext%20x%3D%2732%27%20y%3D%2742%27%20text-anchor%3D%27middle%27%20font-family%3D%27Arial%2C%20sans-serif%27%20font-size%3D%2736%27%20fill%3D%27%2300eaff%27%3ET%3C%2Ftext%3E%0A%3C%2Fsvg%3E">
   <!-- 主要フォントを先読み（同一オリジン想定） -->
   <link rel="preload" as="font" href="assets/fonts/genei-gothic/GenEiGothicP-Bold.woff2" type="font/woff2" crossorigin>
   <link rel="preload" as="font" href="assets/fonts/genei-gothic/GenEiGothicP-SemiBold.woff2" type="font/woff2" crossorigin>
@@ -344,7 +345,7 @@
   <script type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
         import { getDatabase, ref, onValue, update, serverTimestamp, get } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js";
-        import { getAuth, onAuthStateChanged, signInAnonymously } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+        import { getAuth, onAuthStateChanged, signInAnonymously, signOut } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
         const firebaseConfig = {
             apiKey: "AIzaSyBh54ZKsM6uNph61QrP-Ypu7bzU_PHbNcY",
@@ -459,6 +460,7 @@
         async function callGas(action, extra = {}) {
           const user = auth.currentUser;
           if (!user) throw new Error('Not signed in');
+          if (!user.isAnonymous) throw new Error('Display authentication must be anonymous');
           const idToken = await user.getIdToken();
           latestIdToken = idToken;
           const res = await fetch(GAS_API_URL, {
@@ -561,7 +563,7 @@
           }
         }
 
-        onAuthStateChanged(auth, (user) => {
+        onAuthStateChanged(auth, async (user) => {
           if (!user) {
             resetSessionState();
             signInAnonymously(auth).catch(err => {
@@ -569,6 +571,18 @@
             });
             return;
           }
+
+          if (!user.isAnonymous) {
+            console.warn('Non-anonymous user detected on display; re-authenticating anonymously.');
+            resetSessionState();
+            try {
+              await signOut(auth);
+            } catch (err) {
+              console.error('Failed to sign out non-anonymous user:', err);
+            }
+            return;
+          }
+
           beginDisplaySession().catch(err => {
             console.error('Failed to establish display session:', err);
           });

--- a/operator.html
+++ b/operator.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Telop Operator</title>
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2064%2064%27%3E%0A%20%20%3Crect%20width%3D%2764%27%20height%3D%2764%27%20rx%3D%2712%27%20fill%3D%27%2305111f%27%2F%3E%0A%20%20%3Ctext%20x%3D%2732%27%20y%3D%2742%27%20text-anchor%3D%27middle%27%20font-family%3D%27Arial%2C%20sans-serif%27%20font-size%3D%2736%27%20fill%3D%27%2300eaff%27%3ET%3C%2Ftext%3E%0A%3C%2Fsvg%3E">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/toastify-js"></script>


### PR DESCRIPTION
## Summary
- ensure the display page signs out any remembered non-anonymous user before starting a session
- guard GAS calls so they only run after an anonymous sign-in
- embed a shared inline SVG favicon for both operator and display pages to prevent 404s

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e685ffdbd483258a9e46941c35e73e