### PR TITLE
Streamline telop clearing and remove manual display approval UI

### DIFF
--- a/operator.html
+++ b/operator.html
@@ -94,18 +94,6 @@
         </div>
         <div class="panel" id="dictionary-panel">
             <h2>ルビ辞書管理</h2>
-            <section class="display-approval" aria-label="表示端末の承認">
-                <h3>表示端末の承認</h3>
-                <p class="form-note">表示画面のブラウザコンソールに表示された UID を入力し、承認を登録してください。</p>
-                <form id="approve-display-form" class="stacked-form">
-                    <label for="approve-display-uid" class="visually-hidden">Display UID</label>
-                    <div class="form-row">
-                        <input type="text" id="approve-display-uid" autocomplete="off" placeholder="例: h9rmnA1AzBZou3H0GJ1X564KGq33" required>
-                        <button type="submit">UIDを承認</button>
-                    </div>
-                </form>
-                <p id="approve-display-feedback" class="form-note" aria-live="polite"></p>
-            </section>
             <button id="fetch-dictionary-button">辞書を更新</button>
             <form id="add-term-form">
                 <input type="text" id="new-term" placeholder="単語" required>


### PR DESCRIPTION
## Summary
- Remove the manual display approval section from the operator panel and delete the corresponding client-side handlers.
- Update the telop clearing routine to reset selecting flags via RTDB and trigger GAS synchronization in the background, matching the display flow.

## Testing
- Not run (not provided).

------
https://chatgpt.com/codex/tasks/task_e_68e687a4e26c832591a8bb7fc9f7af78