### PR TITLE
参加者メールに17:00〜22:00のアクセス集中注意文を追加

### DIFF
--- a/public/email-participant-body.html
+++ b/public/email-participant-body.html
@@ -206,6 +206,10 @@
         ご質問や相談は、下のフォームから投稿いただけます。<br>
         <strong>是非、ご投稿ください！</strong>
     </p>
+    <p style="margin:0 0 14px; padding:10px 12px; text-align:center; border:2px solid #d93025; border-radius:8px; background:#fff4cc; color:#b31412; font-weight:800; font-size:16px; line-height:1.7;">
+      ⚠️ <strong>17:00〜22:00はアクセス集中により大変つながりにくくなります。</strong><br>
+      そのため、上記時間帯の<strong>質問募集フォームへの接続はお控えください</strong>。
+    </p>
     <p style="text-align:center; margin:0 0 12px;">
       <a href="<?= questionFormUrl ?>" class="button" target="_blank" rel="noopener" style="<?= buttonStyle ?>"><?= questionFormLabel || '質問フォームを開く' ?></a>
     </p>


### PR DESCRIPTION
### Motivation
- `17:00〜22:00`の時間帯はアクセス集中で繋がりにくくなるため、参加者向けメールの質問フォーム案内直前にその旨を明示し、目立つ形で案内することを目的としています。

### Description
- `public/email-participant-body.html` に質問フォームリンク直前の箇所へ、警告アイコン・赤枠・淡黄色背景・濃い赤文字・太字などのスタイルを適用した注意文（「17:00〜22:00はアクセス集中のため質問募集フォームへの接続はお控えください」）を追記し、既存の案内文は変更していません。 

### Testing
- 差分の適用は `apply_patch` で行い、変更後の内容を `nl -ba public/email-participant-body.html | sed -n '198,226p'` と `git status --short` で確認し、最終的に `git commit` まで実行しており、いずれも成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9068154148325b44cf121a71d0a48)